### PR TITLE
fix: add "queued" to the CensusSyncRunStatus enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.1.2
+
+Released on July 20th, 2023.
+
+### Added
+- `CensusSyncRunStatus` enum extended to include the `queued` status value - [#28](https://github.com/PrefectHQ/prefect-census/pull/28)
+
 ## 0.1.1
 
 Released on February 2nd, 2023.

--- a/prefect_census/runs.py
+++ b/prefect_census/runs.py
@@ -38,6 +38,7 @@ class CensusSyncRunStatus(Enum):
     FAILED = "failed"
     COMPLETED = "completed"
     SKIPPED = "skipped"
+    QUEUED = "queued"
 
     @classmethod
     def is_terminal_status_code(cls, status_code: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,10 @@ def mock_successful_sync_with_wait(respx_mock):
         side_effect=[
             Response(
                 200,
+                json={"data": {"id": 5, "sync_run_id": 12345, "status": "queued"}},
+            ),
+            Response(
+                200,
                 json={"data": {"id": 5, "sync_run_id": 12345, "status": "working"}},
             ),
             Response(


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes https://github.com/PrefectHQ/prefect-census/issues/25

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-census/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-census/blob/main/CHANGELOG.md)
